### PR TITLE
Basic RGBW support working

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/ledctl.iml
+++ b/.idea/ledctl.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ledctl.iml" filepath="$PROJECT_DIR$/.idea/ledctl.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/pixarray/pixarray.go
+++ b/pixarray/pixarray.go
@@ -12,24 +12,42 @@ const (
 	GBR
 	RGB
 	RBG
+	GRBW
+	BRGW
+	BGRW
+	GBRW
+	RGBW
+	RBGW
 )
 
 var StringOrders map[string]int = map[string]int{
-	"GRB": GRB,
-	"BRG": BRG,
-	"BGR": BGR,
-	"GBR": GBR,
-	"RGB": RGB,
-	"RBG": RBG,
+	"GRB":  GRB,
+	"BRG":  BRG,
+	"BGR":  BGR,
+	"GBR":  GBR,
+	"RGB":  RGB,
+	"RBG":  RBG,
+	"GRBW": GRBW,
+	"BRGW": BRGW,
+	"BGRW": BGRW,
+	"GBRW": GBRW,
+	"RGBW": RGBW,
+	"RBGW": RBGW,
 }
 
 var offsets map[int][]int = map[int][]int{
-	GRB: {0, 1, 2, -1},
-	BRG: {2, 1, 0, -1},
-	BGR: {1, 2, 0, -1},
-	GBR: {0, 2, 1, -1},
-	RGB: {1, 0, 2, -1},
-	RBG: {2, 0, 1, -1},
+	GRB:  {0, 1, 2, -1},
+	BRG:  {2, 1, 0, -1},
+	BGR:  {1, 2, 0, -1},
+	GBR:  {0, 2, 1, -1},
+	RGB:  {1, 0, 2, -1},
+	RBG:  {2, 0, 1, -1},
+	GRBW: {0, 1, 2, 3},
+	BRGW: {2, 1, 0, 3},
+	BGRW: {1, 2, 0, 3},
+	GBRW: {0, 2, 1, 3},
+	RGBW: {1, 0, 2, 3},
+	RBGW: {2, 0, 1, 3},
 }
 
 func abs(i int) int {


### PR DESCRIPTION
Updated to get basic RGBW support working.  

Tested with `SK6812RGBW` leds (Adafruit Neopixel RGBW strip) on a Raspberry Pi 4.